### PR TITLE
FIX - Mac OS X Sierra에서 QTKit이 사라져서 opencv 빌드가 안 되는 문제 수정

### DIFF
--- a/ext/nuvo_image/CMakeLists.txt
+++ b/ext/nuvo_image/CMakeLists.txt
@@ -115,14 +115,25 @@ ExternalProject_Add(
         BUILD_IN_SOURCE 1
 )
 
-ExternalProject_Add(
-        opencv
-        URL ${EXTERNAL_DIR}/3.1.0.zip
-        SOURCE_DIR ${EXTERNAL_SRC_DIR}/opencv3.1.0
-        PATCH_COMMAND cat ${EXTERNAL_DIR}/opencv_patch.cmake >> ${EXTERNAL_SRC_DIR}/opencv3.1.0/cmake/OpenCVFindLibsVideo.cmake
-        CMAKE_ARGS -C${EXTERNAL_DIR}/opencv_config.cmake
-        BUILD_IN_SOURCE 1
-)
+if(APPLE)
+        ExternalProject_Add(
+                opencv
+                URL ${EXTERNAL_DIR}/opencv-master.zip
+                SOURCE_DIR ${EXTERNAL_SRC_DIR}/opencv-master
+                PATCH_COMMAND cat ${EXTERNAL_DIR}/opencv_patch.cmake >> ${EXTERNAL_SRC_DIR}/opencv-master/cmake/OpenCVFindLibsVideo.cmake
+                CMAKE_ARGS -C${EXTERNAL_DIR}/opencv_config.cmake
+                BUILD_IN_SOURCE 1
+        )
+else()
+        ExternalProject_Add(
+                opencv
+                URL ${EXTERNAL_DIR}/3.1.0.zip
+                SOURCE_DIR ${EXTERNAL_SRC_DIR}/opencv3.1.0
+                PATCH_COMMAND cat ${EXTERNAL_DIR}/opencv_patch.cmake >> ${EXTERNAL_SRC_DIR}/opencv3.1.0/cmake/OpenCVFindLibsVideo.cmake
+                CMAKE_ARGS -C${EXTERNAL_DIR}/opencv_config.cmake
+                BUILD_IN_SOURCE 1
+        )
+endif()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/build/bin)
 


### PR DESCRIPTION
### 문제점
- 애플이 sierra에서 qtkit 없애버림
- https://github.com/opencv/opencv/pull/7159 에서 수정됐지만 아직 정식으로 배포되진 않았음

### 수정 사항
- mac os x일 때는 최신 버전 opencv를 빌드하도록 수정함